### PR TITLE
Use anchors instead of checkbox hack

### DIFF
--- a/_includes/list.html
+++ b/_includes/list.html
@@ -7,7 +7,7 @@
 <div class="{{ include.class | default: "projects" }}">
 <section class="list">
     {%- for project in include.data -%}
-    <div class="item{% if project.star %} star{% endif %}">
+    <div class="item{% if project.star %} star{% endif %}{% if include.class == 'papers' and project.content %} anchor" id="{{ project.slug }}{% endif %}">
         <h4>
             <a class="title" href="
             {%- if project.url_is_pdf -%}
@@ -35,6 +35,11 @@
         {%- if project.description -%}
         <p class="description">{{ project.description }}</p>
         {%- endif -%}
+
+        {% if include.class == "papers" and project.content %}
+        <a class="atoggle aon" href="#{{ project.slug }}">Abstract</a>
+        <a class="atoggle aoff" href="#!">Abstract</a>
+        {% endif %}
         
         {%- if project.github -%}
         <a class="icon-link" href="{{ project.github }}" target="_blank">
@@ -61,12 +66,8 @@
         </a>
         {%- endif -%}
         {% if include.class == "papers" and project.content %}
-        <div class="atoggle">
-            <input type="checkbox" id="toggle" name="abstract-toggle" />
-            <label for="toggle">Abstract</label>
-            <div class = "abstract content">
-                {{ project.content | markdownify }}
-            </div>
+        <div class = "abstract content">
+            {{ project.content | markdownify }}
         </div>
         {% endif %}
     </div>

--- a/_sass/base/helpers.sass
+++ b/_sass/base/helpers.sass
@@ -28,12 +28,8 @@
  * offset for anchor links on headers due to fixed navbar
  */
 
-.anchor:target:before,
-h2:target:before
-	content: ""
-	display: block
-	height: 70px
-	margin: -70px 0 0
+.anchor, h2
+	scroll-margin-top: 70px
 
 /*
  * animations

--- a/_sass/components/list.sass
+++ b/_sass/components/list.sass
@@ -21,35 +21,31 @@
         .description
             margin: 0
 
-        .icon-link
-                ~ .atoggle
-                    display: inline //don't want to newline iff icon-link
+        .atoggle
+            margin:
+                top: 0.4em //same as the icons
+                right: 0.4em
+            color: $alpha
+            text-decoration: none
+            &::before
+                margin-right: 0.2em
+            &.aon::before
+                content: "▼"
+            &.aoff
+                display: none
+                &::before
+                    content: "▲"
+            &:hover
+                color: $delta
         
         .abstract
             display: none //hide when unchecked
 
-        .atoggle
-            margin-top: 0.4em //same as the icons
-            display: inline-block
-            position: relative
-            label
-                &::before
-                    margin-right: 0.2em
-                    content: "▼"
-            [type="checkbox"]
-                cursor: pointer
-                position: absolute
-                top: 0
-                left: 0
-                width: 100%
-                height: 100%
-                opacity: 0
-                margin: 0
-                z-index: 1
-                &:hover ~ label
-                    color: $delta
-                &:checked ~ label
-                    &::before
-                        content: "▲" 
-                    ~ .abstract
-                        display: block
+        &:target 
+            .atoggle
+                &.aon
+                    display: none
+                &.aoff
+                    display: inline
+            .abstract
+                display: block


### PR DESCRIPTION
I can use anchors instead of checkboxes to show and hide abstracts. The side effect of scrolling may or may not be desirable.